### PR TITLE
[FIX]: Typo variable state and set loading state

### DIFF
--- a/components/category-detail.tsx
+++ b/components/category-detail.tsx
@@ -16,19 +16,21 @@ type PropsCategoryDetail = {
 const CategoryDetail = ({ categoryId }: PropsCategoryDetail) => {
   const [creators, setCreators] = useState<Creator[]>([])
   const [isSearching, setIsSearching] = useState<boolean>(false)
-  const [isLoading, setIsLoding] = useState<boolean>(true)
+  const [isLoading, setIsLoading] = useState<boolean>(true)
   const [query, setQuery] = useState<string>('')
 
   // TODO: Check if this useEffect is an anti-pattern
   useEffect(() => {
     if (!categoryId) return
+
+    setIsLoading(true)
     api
       .search(categoryId)
       .then((data) => {
         setCreators(data)
       })
       .finally(() => {
-        setIsLoding(false)
+        setIsLoading(false)
       })
 
     return () => {


### PR DESCRIPTION
Hola!

- Dentro del componente `category-detail`, la variable setter para el estado `loading` presenta un typo, se modifica de `setIsLoding` a `setIsLoading`
- Se modifica estado `loading` a true, cada vez que la variable `categoryId` presenta un cambio (o sea, cada vez que se cambia entre categorías), al no modificar el estado, siempre era `false`, mostrando siempre el mensaje de `No se encontraron resultados para...`

Gracias, feliz día!